### PR TITLE
Simplified the usage of sendpush, no need to pass an object anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,12 +325,9 @@ getConsumption(resolution: EnergyResolution, lastCount: number, homeId?: string)
 /**
      * Sends a push notification to the current user's tibber app.
      * Returns a ISendPushNotification Object
-     * @param messagePayloadVariables ISendPushNotificationPayload.
-     *  input: {
-        title: "The title of your message";
-        message: "The message you want to send";
-        screenToOpen: AppScreen Object, example: AppScreen.HOME ;
-    };
+     * @param title: "The title of your message";
+       @param message: "The message you want to send";
+       @param screenToOpen: AppScreen Object, example: AppScreen.HOME ;
      * @return ISendPushNotification Object
      */
 ```

--- a/examples/push-notification.ts
+++ b/examples/push-notification.ts
@@ -3,7 +3,6 @@
 
 import { TibberQuery, IConfig } from '../src/index';
 import http from 'http';
-import { ISendPushNotificationPayload } from '../src/models/ISendPushNotificationPayload';
 import { AppScreen } from '../src/models/enums/AppScreen';
 
 const hostname = '127.0.0.1';
@@ -21,17 +20,17 @@ const config: IConfig = {
 
 // Instance of TibberQuery
 const tibberQuery = new TibberQuery(config);
+// your push config
+const message = 'TEST_MESSAGE';
+const title = 'TEST_TITLE';
+const screenToOpen = AppScreen.HOME;
 
 // Simple web server.
 const server = http.createServer(async (req, res) => {
     // Call the Tibber API and return the result.
-    const messagePayloadVariables: ISendPushNotificationPayload = {
-        input: { title: 'TITLE', message: 'MESSAGE', screenToOpen: AppScreen.HOME },
-    };
-
     switch (req.url) {
         case '/push':
-            const result = await tibberQuery.sendPushNotification(messagePayloadVariables);
+            const result = await tibberQuery.sendPushNotification(message, title, screenToOpen);
             res.statusCode = 200;
             res.setHeader('Content-Type', 'application/json');
             res.end(JSON.stringify(result));

--- a/src/models/IErrors.ts
+++ b/src/models/IErrors.ts
@@ -1,0 +1,13 @@
+export interface IErrors {
+    message: string;
+    locations: [
+        {
+            line: number;
+            column: number;
+        },
+    ];
+    path: string[];
+    extensions: {
+        code: string;
+    };
+}

--- a/src/models/ISendPushNotification.ts
+++ b/src/models/ISendPushNotification.ts
@@ -1,21 +1,9 @@
+import { IErrors } from './IErrors';
+
 export interface ISendPushNotification {
     sendPushNotification?: {
         successful: string;
         pushedToNumberOfDevices: number;
     };
-    errors?: [
-        {
-            message: string;
-            locations: [
-                {
-                    line: number;
-                    column: number;
-                },
-            ];
-            path: string[];
-            extensions: {
-                code: string;
-            };
-        },
-    ];
+    errors?: IErrors[];
 }

--- a/src/nodes/TibberQuery.ts
+++ b/src/nodes/TibberQuery.ts
@@ -12,7 +12,7 @@ import { gqlCurrentEnergyPrice, gqlTodaysEnergyPrices, gqlTomorrowsEnergyPrices,
 import { HttpMethod } from './models/HttpMethod';
 import { gqlSendPushNotification } from '../gql/sendPushNotification.gql';
 import { ISendPushNotification } from '../models/ISendPushNotification';
-import { ISendPushNotificationPayload } from '../models/ISendPushNotificationPayload';
+import { AppScreen as screenToOpen } from '../models/enums/AppScreen';
 
 export class TibberQuery {
     public active: boolean;
@@ -274,19 +274,20 @@ export class TibberQuery {
             return result && result.error ? result : { error: 'An error occurred while loadnig consumption.' };
         }
     }
-
     /**
      * Sends a push notification to the current user's tibber app.
      * Returns a ISendPushNotification Object
-     * @param messagePayloadVariables ISendPushNotificationPayload. 
-     * input: {
-        title: "The title of your message";
-        message: "The message you want to send";
-        screenToOpen: AppScreen Object, example: AppScreen.HOME ;
-        };
+     * @param title: "The title of your message";
+       @param message: "The message you want to send";
+       @param screenToOpen: AppScreen Object, example: AppScreen.HOME ;
      * @return ISendPushNotification Object
      */
-    public async sendPushNotification(messagePayloadVariables: ISendPushNotificationPayload): Promise<ISendPushNotification> {
+
+    public async sendPushNotification(message: string, title: string, screen: screenToOpen): Promise<ISendPushNotification> {
+        const messagePayloadVariables = {
+            input: { title: title, message: message, screenToOpen: screen },
+        };
+
         const result = await this.query(gqlSendPushNotification, messagePayloadVariables);
 
         if (result.sendPushNotification || result.errors) {

--- a/tests/test2-integration-tibber-query.ts
+++ b/tests/test2-integration-tibber-query.ts
@@ -4,7 +4,6 @@ import { EnergyResolution } from '../src/models/enums/EnergyResolution';
 import { IConsumption } from '../src/models/IConsumption';
 import { AppScreen } from '../src/models/enums/AppScreen';
 import { ISendPushNotification } from '../src/models/ISendPushNotification';
-import { ISendPushNotificationPayload } from '../src/models/ISendPushNotificationPayload';
 
 const config: IConfig = {
     active: false,
@@ -123,12 +122,12 @@ test('TibberQuery.getTomorrowsEnergyPrices() should be valid', async () => {
 });
 
 test('TibberQuery.sendPushNotification() should return error when using demo user', async () => {
-    const messagePayloadVariables: ISendPushNotificationPayload = {
-        input: { title: 'TEST_TITLE', message: 'TEST_MESSAGE', screenToOpen: AppScreen.HOME },
-    };
     const tibberQuery = new TibberQuery(config);
+    const message = 'TEST_MESSAGE';
+    const title = 'TEST_TITLE';
+    const screenToOpen = AppScreen.HOME;
 
     process.nextTick(() => {});
-    const result: ISendPushNotification = await tibberQuery.sendPushNotification(messagePayloadVariables);
+    const result: ISendPushNotification = await tibberQuery.sendPushNotification(title, message, screenToOpen);
     if (result.errors != undefined) result.errors.map((m) => expect(m.message).toContain('operation not allowed for demo user'));
 });


### PR DESCRIPTION
Why: 
When I started implementing the sendPushNotification I realized the usage of it was not super crisp. So I removed the passing of an object and replaced it with 3 params and the tibberQuery.sendPushNotification() will create the object.