### PR TITLE
Use node type URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,8 @@ typings/
 # next.js build output
 .next
 
+# IDE files
+.idea/
+
+# Others
 lib/

--- a/src/nodes/TibberQueryBase.ts
+++ b/src/nodes/TibberQueryBase.ts
@@ -25,7 +25,7 @@ export class TibberQueryBase {
     }
 
     /**
-     * Try to parse a string and return a valid JSON object. 
+     * Try to parse a string and return a valid JSON object.
      * If string is not valid JSON, it will return an empty object instead.
      * @param input Input string to try to parse as a JSON object
      * @returns Parsed or empty Json object
@@ -127,10 +127,10 @@ export class TibberQueryBase {
      * @param homeId Tibber home ID
      * @return IHome object
      */
-    public async getWebsocketSubscriptionUrl(): Promise<URL> {
+    public async getWebsocketSubscriptionUrl(): Promise<url.URL> {
         const result = await this.query(qglWebsocketSubscriptionUrl);
         if (result && result.viewer && result.viewer.websocketSubscriptionUrl) {
-            return new URL(result.viewer.websocketSubscriptionUrl);
+            return new url.URL(result.viewer.websocketSubscriptionUrl);
         }
         return result && result.error ? result : {};
     }


### PR DESCRIPTION
Instead of the globally "available" DOM URL. Makes it work on pure backend-environments where there is no DOM available

As found out in my own project when bumping to 5.0.0:

```
$ npm run build

> homebridge-tibber-price@1.0.2 build
> rimraf ./dist && tsc

node_modules/tibber-api/lib/src/nodes/TibberQueryBase.d.ts:42:44 - error TS2304: Cannot find name 'URL'.

42     getWebsocketSubscriptionUrl(): Promise<URL>;

```