### PR TITLE
Add resolution to current price queries and updateHome mutation

### DIFF
--- a/.claude/skills/tibber-graphql-api/SKILL.md
+++ b/.claude/skills/tibber-graphql-api/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: tibber-graphql-api
+description: Working knowledge of the Tibber GraphQL API — endpoint, authentication, price/consumption queries (incl. QUARTER_HOURLY resolution), mutations, and the live-measurement websocket subscription API. Use when developing or debugging the tibber-api library or anything calling api.tibber.com.
+---
+
+# Tibber GraphQL API Reference
+
+Practical reference for the Tibber developer API (https://developer.tibber.com), written for maintaining the `bisand/tibber-api` TypeScript library. Verified against the live docs (overview, guides, schema reference, changelog) as of 2026-07.
+
+## Endpoints
+
+| Purpose | URL |
+|---|---|
+| GraphQL queries & mutations (HTTP POST) | `https://api.tibber.com/v1-beta/gql` |
+| WebSocket subscriptions | **Dynamic** — must be queried via `viewer.websocketSubscriptionUrl` |
+| Current value returned for the WS URL | `wss://websocket-api.tibber.com/v1-beta/gql/subscriptions` (do not hardcode) |
+| API explorer (GraphiQL) | `https://developer.tibber.com/explorer` |
+
+The old static WS endpoint `wss://api.tibber.com/v1-beta/gql/subscriptions` was removed in December 2022 along with the legacy `graphql-ws` (subscriptions-transport-ws) sub-protocol.
+
+## Authentication
+
+- OAuth bearer token passed on **every** request: `Authorization: Bearer <token>`.
+- Two token types:
+  1. **Personal Access Token** — access to your own data only; created at https://developer.tibber.com/settings/access-token. Tokens carry **scopes** (e.g. USER, HOME) chosen at creation.
+  2. **OAuth client** — for apps distributed to other users; standard OAuth handshake yields a token on the user's behalf (contact hello@tibber.com to register).
+- **Demo token** (docs examples, backed by an auto-generated demo account whose data may be nonsensical):
+  `3A77EECF61BD445F47241A5A36202185C35AF3AF58609E19B53F3A8872AD7BE1-1`
+
+### Mandatory client requirements
+
+- Set a `User-Agent` header on every GraphQL call, on the call fetching the WS URL, and on the WebSocket connection itself. It must include both platform and driver version, e.g. `Homey/10.0.0 com.tibber/1.8.3`.
+- Implement jitter + exponential backoff on all retries/reconnects.
+
+## Calling the API
+
+Always HTTP **POST**, JSON body with the query as a *string* property:
+
+```bash
+curl \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: my-platform/1.0 tibber-api/6.0.0" \
+  -X POST \
+  -d '{ "query": "{viewer {homes {currentSubscription {priceInfo {current {total energy tax startsAt}}}}}}" }' \
+  https://api.tibber.com/v1-beta/gql
+```
+
+### Error handling (changed 2025-01-03 — potentially breaking)
+
+Authentication failures (missing/invalid token) **no longer return HTTP 400**. The server now returns **HTTP 200** with a GraphQL `errors` array; the error object has `extensions.code === "UNAUTHENTICATED"`. Do not rely on HTTP status codes to detect auth errors — inspect the `errors` array:
+
+```json
+{ "errors": [ { "message": "...", "extensions": { "code": "UNAUTHENTICATED" } } ] }
+```
+
+### Rate limits & best practices
+
+- **100 requests per 5 minutes per IP address** (protective limit).
+- Max **2 concurrently open WebSockets** per token.
+- Prices are computed once per day (afternoon; NO/SE first preliminary, later finalized). Fetch `today`/`tomorrow` **once per day**, cache locally, and pick the current price from the cache instead of polling `priceInfo.current`.
+- Add a long random delay when querying prices; waiting an hour or two after tomorrow's prices normally arrive improves first-try success.
+- Prefer several small queries (prices, consumption, production separately) over one giant query; large consumption queries that time out should be split into smaller time windows and stitched.
+- Consumption/production is **not real-time** — don't poll it continually. It is also cached aggressively server-side; if readings look stale, wait and re-fetch.
+
+## Schema overview
+
+```
+Query
+└── viewer: Viewer!
+    ├── login, userId, name, accountType: [String!]!
+    ├── homes: [Home]!
+    ├── home(id: ID!): Home!
+    └── websocketSubscriptionUrl: String
+
+Home
+├── id, timeZone!, appNickname, appAvatar!, size, type!, numberOfResidents,
+│   primaryHeatingSource, hasVentilationSystem, mainFuseSize
+├── address, owner: LegalEntity, meteringPointData
+├── currentSubscription: Subscription        # current/latest subscription
+├── subscriptions: [Subscription]!           # historic
+├── consumption(resolution: EnergyResolution!, first, last, before, after, filterEmptyNodes)
+├── production(resolution: EnergyResolution!, ...same args)
+└── features { realTimeConsumptionEnabled }  # true if Pulse/Watty paired
+
+Subscription (the power-deal object, NOT a GraphQL subscription)
+├── id, subscriber: LegalEntity!, validFrom, validTo, status
+├── priceInfo(resolution: PriceInfoResolution): PriceInfo      # HOURLY | QUARTER_HOURLY
+├── priceInfoRange(resolution: PriceInfoRangeResolution!, first, last, before, after)
+└── priceRating  ⚠️ DEPRECATED (use priceInfo)
+```
+
+## Price queries
+
+### PriceInfo — `resolution` argument (added 2025-09-01)
+
+`Subscription.priceInfo` takes an optional `resolution: PriceInfoResolution` argument:
+
+| Enum `PriceInfoResolution` | Behavior |
+|---|---|
+| `HOURLY` (default) | 24 items in `today`/`tomorrow`; `current` = current hour |
+| `QUARTER_HOURLY` | **96** items in `today`/`tomorrow`; `current` = current quarter-hour |
+
+Background: European day-ahead markets (Nord Pool, EPEX) switched to 15-minute MTUs on 2025-09-30; the first day with real quarter-hourly prices was **2025-10-01**. Before that date, `QUARTER_HOURLY` returned 4 identical prices per hour. The change is opt-in/backward-compatible — omitting `resolution` still yields `HOURLY`. Tibber has said the default *may* change to `QUARTER_HOURLY` in the future (with advance notice in the changelog), so always pass the argument explicitly.
+
+```graphql
+{
+  viewer {
+    home(id: "my-home-id") {
+      currentSubscription {
+        priceInfo(resolution: QUARTER_HOURLY) {
+          current { total energy tax startsAt currency level }
+          today    { startsAt total energy tax level }
+          tomorrow { startsAt total energy tax level }
+        }
+      }
+    }
+  }
+}
+```
+
+### Price fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `total` | Float | energy + taxes |
+| `energy` | Float | Nord Pool spot price |
+| `tax` | Float | certificates + energy tax (SE) + VAT |
+| `startsAt` | String | ISO8601 start time of the price period |
+| `currency` | String! | |
+| `level` | PriceLevel | vs. trailing average |
+
+`PriceLevel` enum: `VERY_CHEAP` (≤60 % of avg), `CHEAP` (60–90 %), `NORMAL` (90–115 %), `EXPENSIVE` (115–140 %), `VERY_EXPENSIVE` (≥140 %).
+
+### Historical prices: `priceInfoRange` (replaces `priceInfo.range`)
+
+- `PriceInfo.range` is **deprecated** — it still works but will never support `QUARTER_HOURLY`. Migrate to `Subscription.priceInfoRange`.
+- `priceInfoRange(resolution: PriceInfoRangeResolution!, first, last, before, after)` returns a `SubscriptionPriceConnection` (`nodes: [Price]!`, `edges`, `pageInfo` with `count`, cursors, `minTotal`/`maxTotal` etc.).
+- `PriceInfoRangeResolution` enum: `DAILY` | `HOURLY` | `QUARTER_HOURLY`.
+- Result caps: **672 items (7 days) QUARTER_HOURLY, 744 items (31 days) HOURLY, 31 items DAILY.** Longer ranges are silently capped, not errored — paginate with cursors.
+- Cursors (`before`/`after`) are **Base64-encoded ISO8601 date/time strings**. `before` can't combine with `after`; `first` can't combine with `last`.
+- History from before Tibber's quarter-hourly backend support still returns hourly items even with `resolution: QUARTER_HOURLY`.
+- Prices never change once published — cache historical prices permanently.
+
+### Deprecated: `priceRating`
+
+`Subscription.priceRating` (hourly/daily/monthly aggregates with LOW/NORMAL/HIGH levels) is deprecated as of 2025-09-01 and will not get quarter-hourly support. It still works; migrate to `priceInfo`. (Historical irony: in 2021 the docs deprecated `priceInfo` in favor of `priceRating`; this was reversed.)
+
+## Consumption & production
+
+`Home.consumption` / `Home.production` take a required `resolution: EnergyResolution!`:
+
+`EnergyResolution` enum: `HOURLY` | `DAILY` | `WEEKLY` | `MONTHLY` | `ANNUAL`
+
+**These do NOT accept QUARTER_HOURLY** — as of the 2025-09-01 changelog they remain hourly at finest; Tibber is evaluating 15-minute support based on demand.
+
+Result caps (since 2024-10-18/24, silently capped): 744 (HOURLY, a full 31-day month), 31 (DAILY), 52 (WEEKLY), 12 (MONTHLY), 1 (ANNUAL).
+
+```graphql
+{
+  viewer {
+    home(id: "my-home-id") {
+      consumption(resolution: HOURLY, last: 24, filterEmptyNodes: true) {
+        pageInfo { startCursor endCursor count totalCost totalConsumption currency filtered }
+        nodes { from to consumption consumptionUnit cost unitPrice unitPriceVAT currency }
+      }
+      production(resolution: HOURLY, last: 24) {
+        nodes { from to production productionUnit profit unitPrice currency }
+      }
+    }
+  }
+}
+```
+
+Field notes:
+- `Consumption.cost` = consumption × unitPrice, incl. VAT, excl. fees/production reward/Grid Rewards. `totalCost` and `unitCost` are **deprecated** in favor of `cost`; `energyCost` on pageInfo is deprecated as redundant.
+- Pagination: same `first`/`last`/`before`/`after` Base64-ISO8601 cursor scheme as prices; `filterEmptyNodes` (default false) drops empty entries and reports the count in `pageInfo.filtered`.
+
+## Mutations
+
+```graphql
+mutation {
+  sendPushNotification(input: {
+    title: "Price alert", message: "Cheap power now!", screenToOpen: CONSUMPTION
+  }) {
+    successful
+    pushedToNumberOfDevices
+  }
+}
+
+mutation {
+  updateHome(input: { homeId: "my-home-id", appNickname: "Cabin", appAvatar: COTTAGE }) {
+    appNickname
+    appAvatar
+  }
+}
+```
+
+| Mutation | Input | Returns | Status |
+|---|---|---|---|
+| `sendPushNotification` | `PushNotificationInput` (`title`, `message!`, `screenToOpen: AppScreen`) | `PushNotificationResponse` (`successful!`, `pushedToNumberOfDevices!`) | Active |
+| `updateHome` | `UpdateHomeInput` (`homeId!`, `appNickname`, `appAvatar: HomeAvatar`, `size`, `type: HomeType`, `numberOfResidents`, `primaryHeatingSource: HeatingSource`, `hasVentilationSystem`, `mainFuseSize`) | `Home!` | Active |
+| `sendMeterReading` | `MeterReadingInput` (`homeId!`, `time`, `reading!`) | `MeterReadingResponse` | **DEPRECATED — calling it does nothing**; response fields always `null`/`0` |
+
+Enums: `AppScreen` = `HOME, REPORTS, CONSUMPTION, COMPARISON, DISAGGREGATION, HOME_PROFILE, CUSTOMER_PROFILE, METER_READING, NOTIFICATIONS, INVOICES`. `HomeAvatar` = `APARTMENT, ROWHOUSE, FLOORHOUSE1, FLOORHOUSE2, FLOORHOUSE3, COTTAGE, CASTLE`. `HomeType` = `APARTMENT, ROWHOUSE, HOUSE, COTTAGE`.
+
+## Real-time subscription API (liveMeasurement)
+
+### Connection procedure
+
+1. Check the home actually streams: query `viewer.home(id:...).features.realTimeConsumptionEnabled` — must be `true` (a Pulse or Watty device is paired). Also re-check before reconnect attempts (devices get removed).
+2. Query the WS endpoint dynamically:
+   ```graphql
+   { viewer { websocketSubscriptionUrl } }
+   ```
+3. Open a WebSocket to that URL with sub-protocol **`graphql-transport-ws`** (the enisdenjo/graphql-ws protocol; the old Apollo `graphql-ws` protocol was removed Dec 2022) and a proper `User-Agent` header.
+4. Send `connection_init` with the token in the payload (as used by the reference clients — graphql-ws in the Tibber Homey app, pyTibber, Tibber.SDK.NET):
+   ```json
+   { "type": "connection_init", "payload": { "token": "<access token>" } }
+   ```
+   Wait for `connection_ack`, then send `subscribe` with an id and the query payload.
+
+### Subscription query
+
+```graphql
+subscription {
+  liveMeasurement(homeId: "96a14971-525a-4420-aae9-e5aedaa129ff") {
+    timestamp
+    power
+    accumulatedConsumption
+    accumulatedCost
+    currency
+    minPower
+    averagePower
+    maxPower
+  }
+}
+```
+
+There is also `testMeasurement(count: Int, complete: Boolean): LiveMeasurement` for testing streams.
+
+### LiveMeasurement fields
+
+| Field | Type | Meaning |
+|---|---|---|
+| `timestamp` | String! | when usage occurred |
+| `power` | Float! | current consumption, W |
+| `powerProduction` | Float | net production (A-), W |
+| `minPower` / `averagePower` / `maxPower` | Float! | since midnight, W |
+| `minPowerProduction` / `maxPowerProduction` | Float | since midnight, W |
+| `accumulatedConsumption` / `accumulatedProduction` | Float! | since midnight, kWh |
+| `accumulatedConsumptionLastHour` / `accumulatedProductionLastHour` | Float! | since last hour shift, kWh |
+| `accumulatedCost` / `accumulatedReward` | Float | since midnight; requires active Tibber deal; `accumulatedReward` is production only (unrelated to Grid Rewards) |
+| `currency` | String | requires active Tibber deal |
+| `lastMeterConsumption` / `lastMeterProduction` | Float | meter import/export register, kWh |
+| `powerReactive` / `powerProductionReactive` | Float | Q+ / Q-, kVAr |
+| `powerFactor` | Float | active/apparent power, 0–1 |
+| `voltagePhase1/2/3` | Float | may be `null` on some frames; single-phase homes not guaranteed to report on phase 1 |
+| `currentL1/L2/L3` | Float | same nullability caveat |
+| `currentPhase1/2/3` | Float | **DEPRECATED** → use `currentL1/L2/L3` |
+| `signalStrength` | Int | Pulse: dB(m); Watty: percent |
+
+### Reconnect / resilience rules (from the docs)
+
+- If no data received for several minutes: destroy the old socket, reconnect with jitter + exponential backoff.
+- Server restart closes with `code: 1001, reason: "Going away"` → reconnect after a random 1–60 s delay (jitter mandatory, avoids thundering herd).
+- Auth-rejected connection (e.g. deleted account): **do not retry with the same token** — require fresh credentials.
+- Verify `realTimeConsumptionEnabled === true` before reconnecting.
+- Max 2 open WebSockets.
+
+## Changelog highlights (newest first)
+
+- **2025-09-01** — QUARTER_HOURLY support: `priceInfo(resolution:)` added; `priceInfo.range` deprecated → `Subscription.priceInfoRange`; `priceRating` deprecated; consumption/production still hourly-max. First quarter-hourly prices 2025-10-01.
+- **2025-01-03** — auth errors now HTTP 200 + `extensions.code: UNAUTHENTICATED` instead of HTTP 400.
+- **2024-10-18/24** — hard result caps on range/consumption/production (744/31/52/12/1); silent capping; date-range bugfixes; more aggressive caching.
+- **2022-10-10 / Dec 2022** — `websocketSubscriptionUrl` added; static WS URL and old sub-protocol removed. Clients MUST fetch the URL dynamically and speak `graphql-transport-ws`.
+- **2021-03-14** — `accumulatedConsumptionLastHour`/`accumulatedProductionLastHour` added.
+- **2020** — `powerReactive`, `powerProductionReactive`, `signalStrength`, `currentL1/2/3` (replacing `currentPhase1/2/3`), `Viewer.userId`.
+- **2019** — production connection, `powerFactor`, `minPowerProduction`/`maxPowerProduction`, `Price.level`, `lastMeterConsumption`/`lastMeterProduction`.
+- **2018** — `liveMeasurement` subscription, `Home.features`, `sendPushNotification`.
+- **2017** — `sendMeterReading` (now defunct), `updateHome`, `filterEmptyNodes`.
+
+## Gotchas for tibber-api maintainers
+
+- Two things named "Subscription": the GraphQL root subscription (`liveMeasurement`) and the `Subscription` object type (the customer's power deal, under `home.currentSubscription`). Don't confuse them.
+- `resolution` argument appears on **four** fields with **three different enums**: `priceInfo(PriceInfoResolution: HOURLY|QUARTER_HOURLY)`, `priceInfoRange(PriceInfoRangeResolution: DAILY|HOURLY|QUARTER_HOURLY)`, and `consumption`/`production` (`EnergyResolution: HOURLY|DAILY|WEEKLY|MONTHLY|ANNUAL` — no QUARTER_HOURLY).
+- `sendMeterReading` is a silent no-op now — surface a deprecation warning rather than trusting `MeterReadingResponse`.
+- Result capping is silent: asking for 2000 hourly consumption nodes returns 744 with no error. Check `pageInfo.count`/`hasNextPage`.
+- HTTP 200 does not mean success — always check the `errors` array, and map `extensions.code === "UNAUTHENTICATED"` to an auth failure.
+- Never hardcode the websocket URL; re-query `websocketSubscriptionUrl` on (re)connect.
+- The `/docs/guides/graphql-subscriptions-real-time-api` page no longer exists as a separate guide; WS content now lives in the "Communicating with the API" guide (`/docs/guides/calling-api`) and the overview's "Breaking change in WebSocket subscriptions" section.
+- Demo-account data is auto-generated and can be nonsensical; fine for smoke tests, not for assertions on values.

--- a/Version.ts
+++ b/Version.ts
@@ -1,11 +1,11 @@
-export const version = "5.5.2";
+export const version = "5.6.0";
 export const versionMajor = 5;
-export const versionMinor = 5;
-export const versionPatch = 2;
+export const versionMinor = 6;
+export const versionPatch = 0;
 export const versionPrerelease = [];
-export const release = "5.5.2+20251002200224";
-export const gitSha = "b76465d4adb35db04d09abda6292a7a7d155c577";
-export const gitDate = new Date(1759435344000);
+export const release = "5.6.0+20260706160021";
+export const gitSha = "084b0971a3959cae1d32439e5b28edee259d63d9";
+export const gitDate = new Date(1783346421000);
 export default {
   version,
   versionMajor,

--- a/jestconfig.json
+++ b/jestconfig.json
@@ -1,6 +1,6 @@
 {
   "transform": {
-    "^.+\\.(t|j)sx?$": "ts-jest"
+    "^.+\\.(t|j)sx?$": ["ts-jest", { "tsconfig": { "types": ["jest", "node"], "isolatedModules": true, "rootDir": "." } }]
   },
   "testRegex": "(/tests/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
   "moduleFileExtensions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,33 +1,36 @@
 {
   "name": "tibber-api",
-  "version": "5.5.2",
+  "version": "5.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tibber-api",
-      "version": "5.5.2",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "ws": "^8.18.3"
+        "ws": "^8.21.0"
       },
       "devDependencies": {
-        "@jest/test-sequencer": "^30.2.0",
+        "@jest/test-sequencer": "^30.4.1",
         "@types/jest": "^30.0.0",
-        "@types/node": "^22.15.1",
+        "@types/node": "^26.1.0",
         "@types/ws": "^8.18.1",
-        "@typescript-eslint/eslint-plugin": "^8.45.0",
-        "@typescript-eslint/parser": "^8.45.0",
-        "eslint": "^9.36.0",
-        "jest": "^30.2.0",
-        "jsdoc": "^4.0.4",
-        "jsdoc-to-markdown": "^9.1.2",
-        "mkver": "^4.3.0",
-        "nock": "^14.0.10",
-        "prettier": "^3.6.2",
-        "ts-jest": "^29.4.4",
-        "typescript": "^5.9.3",
+        "@typescript-eslint/eslint-plugin": "^8.62.1",
+        "@typescript-eslint/parser": "^8.62.1",
+        "eslint": "^10.6.0",
+        "jest": "^30.4.2",
+        "jsdoc": "^4.0.5",
+        "jsdoc-to-markdown": "^9.1.3",
+        "mkver": "^5.0.1",
+        "nock": "^14.0.16",
+        "prettier": "^3.9.4",
+        "ts-jest": "^29.4.11",
+        "typescript": "^6.0.3",
         "websocket": "^1.0.35"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -183,9 +186,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -350,13 +353,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -476,13 +479,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -547,21 +550,21 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -570,9 +573,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -581,9 +584,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -600,9 +603,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -610,182 +613,104 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
-      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
-      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@eslint/js": {
-      "version": "9.36.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
-      "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
-      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.2",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -933,16 +858,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -954,17 +869,17 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.2.0.tgz",
-      "integrity": "sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+      "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.2.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
-        "jest-message-util": "30.2.0",
-        "jest-util": "30.2.0",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -972,39 +887,39 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.2.0.tgz",
-      "integrity": "sha512-03W6IhuhjqTlpzh/ojut/pDB2LPRygyWX8ExpgHtQA8H/3K7+1vKmcINx5UzeOX1se6YEsBsOHQ1CRzf3fOwTQ==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.2.0",
-        "@jest/pattern": "30.0.1",
-        "@jest/reporters": "30.2.0",
-        "@jest/test-result": "30.2.0",
-        "@jest/transform": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/console": "30.4.1",
+        "@jest/pattern": "30.4.0",
+        "@jest/reporters": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "exit-x": "^0.2.2",
+        "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-changed-files": "30.2.0",
-        "jest-config": "30.2.0",
-        "jest-haste-map": "30.2.0",
-        "jest-message-util": "30.2.0",
-        "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.2.0",
-        "jest-resolve-dependencies": "30.2.0",
-        "jest-runner": "30.2.0",
-        "jest-runtime": "30.2.0",
-        "jest-snapshot": "30.2.0",
-        "jest-util": "30.2.0",
-        "jest-validate": "30.2.0",
-        "jest-watcher": "30.2.0",
-        "micromatch": "^4.0.8",
-        "pretty-format": "30.2.0",
+        "jest-changed-files": "30.4.1",
+        "jest-config": "30.4.2",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-resolve-dependencies": "30.4.2",
+        "jest-runner": "30.4.2",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1020,9 +935,9 @@
       }
     },
     "node_modules/@jest/diff-sequences": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
-      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1030,39 +945,39 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
-      "integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-mock": "30.2.0"
+        "jest-mock": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.2.0.tgz",
-      "integrity": "sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expect": "30.2.0",
-        "jest-snapshot": "30.2.0"
+        "expect": "30.4.1",
+        "jest-snapshot": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
-      "integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1073,18 +988,18 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
-      "integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.2.0",
-        "@sinonjs/fake-timers": "^13.0.0",
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
         "@types/node": "*",
-        "jest-message-util": "30.2.0",
-        "jest-mock": "30.2.0",
-        "jest-util": "30.2.0"
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1101,62 +1016,62 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.2.0.tgz",
-      "integrity": "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.2.0",
-        "@jest/expect": "30.2.0",
-        "@jest/types": "30.2.0",
-        "jest-mock": "30.2.0"
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/types": "30.4.1",
+        "jest-mock": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/pattern": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "jest-regex-util": "30.0.1"
+        "jest-regex-util": "30.4.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.2.0.tgz",
-      "integrity": "sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+      "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.2.0",
-        "@jest/test-result": "30.2.0",
-        "@jest/transform": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/console": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@jridgewell/trace-mapping": "^0.3.25",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "collect-v8-coverage": "^1.0.2",
         "exit-x": "^0.2.2",
-        "glob": "^10.3.10",
+        "glob": "^10.5.0",
         "graceful-fs": "^4.2.11",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-instrument": "^6.0.0",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^5.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "30.2.0",
-        "jest-util": "30.2.0",
-        "jest-worker": "30.2.0",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
         "slash": "^3.0.0",
         "string-length": "^4.0.2",
         "v8-to-istanbul": "^9.0.1"
@@ -1174,9 +1089,9 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1187,13 +1102,13 @@
       }
     },
     "node_modules/@jest/snapshot-utils": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.2.0.tgz",
-      "integrity": "sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.2.0",
+        "@jest/types": "30.4.1",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "natural-compare": "^1.4.0"
@@ -1218,14 +1133,14 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.2.0.tgz",
-      "integrity": "sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+      "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/console": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "collect-v8-coverage": "^1.0.2"
       },
@@ -1234,15 +1149,15 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.2.0.tgz",
-      "integrity": "sha512-wXKgU/lk8fKXMu/l5Hog1R61bL4q5GCdT6OJvdAFz1P+QrpoFuLU68eoKuVc4RbrTtNnTL5FByhWdLgOPSph+Q==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+      "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.2.0",
+        "@jest/test-result": "30.4.1",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.2.0",
+        "jest-haste-map": "30.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1250,24 +1165,23 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.2.0.tgz",
-      "integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
-        "@jest/types": "30.2.0",
+        "@jest/types": "30.4.1",
         "@jridgewell/trace-mapping": "^0.3.25",
         "babel-plugin-istanbul": "^7.0.1",
         "chalk": "^4.1.2",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.2.0",
-        "jest-regex-util": "30.0.1",
-        "jest-util": "30.2.0",
-        "micromatch": "^4.0.8",
+        "jest-haste-map": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
         "pirates": "^4.0.7",
         "slash": "^3.0.0",
         "write-file-atomic": "^5.0.1"
@@ -1277,14 +1191,14 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
-      "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "@types/istanbul-reports": "^3.0.4",
         "@types/node": "*",
@@ -1359,9 +1273,9 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.39.7",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.7.tgz",
-      "integrity": "sha512-sURvQbbKsq5f8INV54YJgJEdk8oxBanqkTiXXd33rKmofFCwZLhLRszPduMZ9TA9b8/1CHc/IJmOlBHJk2Q5AQ==",
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1377,16 +1291,22 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1464,22 +1384,22 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.41",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
-      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "dev": true,
       "license": "MIT"
     },
@@ -1494,9 +1414,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "13.0.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
-      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1504,9 +1424,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1559,10 +1479,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1637,13 +1564,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.18.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.8.tgz",
-      "integrity": "sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1681,21 +1608,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.45.0.tgz",
-      "integrity": "sha512-HC3y9CVuevvWCl/oyZuI47dOeDF9ztdMEfMH8/DW/Mhwa9cCLnK1oD7JoTVGW/u7kFzNZUKUoyJEqkaJh5y3Wg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.45.0",
-        "@typescript-eslint/type-utils": "8.45.0",
-        "@typescript-eslint/utils": "8.45.0",
-        "@typescript-eslint/visitor-keys": "8.45.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/type-utils": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1705,23 +1631,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.45.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "@typescript-eslint/parser": "^8.62.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.45.0.tgz",
-      "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.45.0",
-        "@typescript-eslint/types": "8.45.0",
-        "@typescript-eslint/typescript-estree": "8.45.0",
-        "@typescript-eslint/visitor-keys": "8.45.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1731,20 +1657,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.45.0.tgz",
-      "integrity": "sha512-3pcVHwMG/iA8afdGLMuTibGR7pDsn9RjDev6CCB+naRsSYs2pns5QbinF4Xqw6YC/Sj3lMrm/Im0eMfaa61WUg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.45.0",
-        "@typescript-eslint/types": "^8.45.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1754,18 +1680,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.45.0.tgz",
-      "integrity": "sha512-clmm8XSNj/1dGvJeO6VGH7EUSeA0FMs+5au/u3lrA3KfG8iJ4u8ym9/j2tTEoacAffdW1TVUzXO30W1JTJS7dA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.45.0",
-        "@typescript-eslint/visitor-keys": "8.45.0"
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1776,9 +1702,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.45.0.tgz",
-      "integrity": "sha512-aFdr+c37sc+jqNMGhH+ajxPXwjv9UtFZk79k8pLoJ6p4y0snmYpPA52GuWHgt2ZF4gRRW6odsEj41uZLojDt5w==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1789,21 +1715,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.45.0.tgz",
-      "integrity": "sha512-bpjepLlHceKgyMEPglAeULX1vixJDgaKocp0RVJ5u4wLJIMNuKtUXIczpJCPcn2waII0yuvks/5m5/h3ZQKs0A==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.45.0",
-        "@typescript-eslint/typescript-estree": "8.45.0",
-        "@typescript-eslint/utils": "8.45.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1813,14 +1739,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.45.0.tgz",
-      "integrity": "sha512-WugXLuOIq67BMgQInIxxnsSyRLFxdkJEJu8r4ngLR56q/4Q5LrbfkFRH27vMTjxEK8Pyz7QfzuZe/G15qQnVRA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1832,22 +1758,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.45.0.tgz",
-      "integrity": "sha512-GfE1NfVbLam6XQ0LcERKwdTTPlLvHvXXhOeUGC1OXi4eQBoyy1iVsW+uzJ/J9jtCz6/7GCQ9MtrQ0fml/jWCnA==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.45.0",
-        "@typescript-eslint/tsconfig-utils": "8.45.0",
-        "@typescript-eslint/types": "8.45.0",
-        "@typescript-eslint/visitor-keys": "8.45.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1857,20 +1782,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.45.0.tgz",
-      "integrity": "sha512-bxi1ht+tLYg4+XV2knz/F7RVhU0k6VrSMc9sb8DQ6fyCTrGQLHfo7lDtN0QJjZjKkLA2ThrKuCdHEvLReqtIGg==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.45.0",
-        "@typescript-eslint/types": "8.45.0",
-        "@typescript-eslint/typescript-estree": "8.45.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1880,19 +1805,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.45.0.tgz",
-      "integrity": "sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==",
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.45.0",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.62.1",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1903,13 +1828,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1923,9 +1848,9 @@
       "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
       "cpu": [
         "arm"
       ],
@@ -1937,9 +1862,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
       "cpu": [
         "arm64"
       ],
@@ -1951,9 +1876,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
       "cpu": [
         "arm64"
       ],
@@ -1965,9 +1890,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
       "cpu": [
         "x64"
       ],
@@ -1979,9 +1904,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
       "cpu": [
         "x64"
       ],
@@ -1993,9 +1918,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
       "cpu": [
         "arm"
       ],
@@ -2007,9 +1932,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
       "cpu": [
         "arm"
       ],
@@ -2021,13 +1946,16 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2035,13 +1963,50 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2049,13 +2014,16 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2063,13 +2031,16 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2077,13 +2048,16 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2091,13 +2065,16 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2105,13 +2082,16 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2119,23 +2099,40 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
       "cpu": [
         "wasm32"
       ],
@@ -2143,16 +2140,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.11"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
       "cpu": [
         "arm64"
       ],
@@ -2164,9 +2163,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
       "cpu": [
         "ia32"
       ],
@@ -2178,9 +2177,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
       "cpu": [
         "x64"
       ],
@@ -2192,9 +2191,9 @@
       ]
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2215,9 +2214,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2308,16 +2307,16 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.2.0.tgz",
-      "integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/transform": "30.2.0",
+        "@jest/transform": "30.4.1",
         "@types/babel__core": "^7.20.5",
         "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.2.0",
+        "babel-preset-jest": "30.4.0",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "slash": "^3.0.0"
@@ -2350,9 +2349,9 @@
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.2.0.tgz",
-      "integrity": "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2390,13 +2389,13 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.2.0.tgz",
-      "integrity": "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "babel-plugin-jest-hoist": "30.2.0",
+        "babel-plugin-jest-hoist": "30.4.0",
         "babel-preset-current-node-syntax": "^1.2.0"
       },
       "engines": {
@@ -2431,13 +2430,26 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2666,9 +2678,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2762,9 +2774,9 @@
       }
     },
     "node_modules/collect-v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2930,9 +2942,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
-      "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3122,34 +3134,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.36.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
-      "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.3.1",
-        "@eslint/core": "^0.15.2",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.36.0",
-        "@eslint/plugin-kit": "^0.3.5",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
+        "ajv": "^6.14.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -3159,8 +3170,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -3168,7 +3178,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -3183,17 +3193,19 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -3212,25 +3224,14 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -3244,19 +3245,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/esniff": {
@@ -3276,31 +3264,31 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -3321,9 +3309,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3401,6 +3389,13 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/exit-x": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
@@ -3412,18 +3407,18 @@
       }
     },
     "node_modules/expect": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
-      "integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.2.0",
+        "@jest/expect-utils": "30.4.1",
         "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.2.0",
-        "jest-message-util": "30.2.0",
-        "jest-mock": "30.2.0",
-        "jest-util": "30.2.0"
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3608,9 +3603,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3624,19 +3619,6 @@
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -3713,6 +3695,7 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3743,17 +3726,30 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/graceful-fs": {
@@ -3763,17 +3759,10 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3827,23 +3816,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/import-local": {
@@ -4077,16 +4049,16 @@
       }
     },
     "node_modules/jest": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
-      "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/core": "30.4.2",
+        "@jest/types": "30.4.1",
         "import-local": "^3.2.0",
-        "jest-cli": "30.2.0"
+        "jest-cli": "30.4.2"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -4104,14 +4076,14 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.2.0.tgz",
-      "integrity": "sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+      "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.1.1",
-        "jest-util": "30.2.0",
+        "jest-util": "30.4.1",
         "p-limit": "^3.1.0"
       },
       "engines": {
@@ -4119,29 +4091,29 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.2.0.tgz",
-      "integrity": "sha512-Fh0096NC3ZkFx05EP2OXCxJAREVxj1BcW/i6EWqqymcgYKWjyyDpral3fMxVcHXg6oZM7iULer9wGRFvfpl+Tg==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.2.0",
-        "@jest/expect": "30.2.0",
-        "@jest/test-result": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "co": "^4.6.0",
         "dedent": "^1.6.0",
         "is-generator-fn": "^2.1.0",
-        "jest-each": "30.2.0",
-        "jest-matcher-utils": "30.2.0",
-        "jest-message-util": "30.2.0",
-        "jest-runtime": "30.2.0",
-        "jest-snapshot": "30.2.0",
-        "jest-util": "30.2.0",
+        "jest-each": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
         "p-limit": "^3.1.0",
-        "pretty-format": "30.2.0",
+        "pretty-format": "30.4.1",
         "pure-rand": "^7.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
@@ -4151,21 +4123,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.2.0.tgz",
-      "integrity": "sha512-Os9ukIvADX/A9sLt6Zse3+nmHtHaE6hqOsjQtNiugFTbKRHYIYtZXNGNK9NChseXy7djFPjndX1tL0sCTlfpAA==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.2.0",
-        "@jest/test-result": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/core": "30.4.2",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.2.0",
-        "jest-util": "30.2.0",
-        "jest-validate": "30.2.0",
+        "jest-config": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -4184,34 +4156,33 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.2.0.tgz",
-      "integrity": "sha512-g4WkyzFQVWHtu6uqGmQR4CQxz/CH3yDSlhzXMWzNjDx843gYjReZnMRanjRCq5XZFuQrGDxgUaiYWE8BRfVckA==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
-        "@jest/pattern": "30.0.1",
-        "@jest/test-sequencer": "30.2.0",
-        "@jest/types": "30.2.0",
-        "babel-jest": "30.2.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/test-sequencer": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-jest": "30.4.1",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "deepmerge": "^4.3.1",
-        "glob": "^10.3.10",
+        "glob": "^10.5.0",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.2.0",
-        "jest-docblock": "30.2.0",
-        "jest-environment-node": "30.2.0",
-        "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.2.0",
-        "jest-runner": "30.2.0",
-        "jest-util": "30.2.0",
-        "jest-validate": "30.2.0",
-        "micromatch": "^4.0.8",
+        "jest-circus": "30.4.2",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-runner": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
         "parse-json": "^5.2.0",
-        "pretty-format": "30.2.0",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -4236,25 +4207,25 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
-      "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/diff-sequences": "30.0.1",
+        "@jest/diff-sequences": "30.4.0",
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "pretty-format": "30.2.0"
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-docblock": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
-      "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+      "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4265,57 +4236,57 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.2.0.tgz",
-      "integrity": "sha512-lpWlJlM7bCUf1mfmuqTA8+j2lNURW9eNafOy99knBM01i5CQeY5UH1vZjgT9071nDJac1M4XsbyI44oNOdhlDQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+      "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "@jest/types": "30.2.0",
+        "@jest/types": "30.4.1",
         "chalk": "^4.1.2",
-        "jest-util": "30.2.0",
-        "pretty-format": "30.2.0"
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.2.0.tgz",
-      "integrity": "sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.2.0",
-        "@jest/fake-timers": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-mock": "30.2.0",
-        "jest-util": "30.2.0",
-        "jest-validate": "30.2.0"
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.2.0.tgz",
-      "integrity": "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.2.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "anymatch": "^3.1.3",
         "fb-watchman": "^2.0.2",
         "graceful-fs": "^4.2.11",
-        "jest-regex-util": "30.0.1",
-        "jest-util": "30.2.0",
-        "jest-worker": "30.2.0",
-        "micromatch": "^4.0.8",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
+        "picomatch": "^4.0.3",
         "walker": "^1.0.8"
       },
       "engines": {
@@ -4325,50 +4296,64 @@
         "fsevents": "^2.3.3"
       }
     },
+    "node_modules/jest-haste-map/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/jest-leak-detector": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.2.0.tgz",
-      "integrity": "sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+      "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "pretty-format": "30.2.0"
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
-      "integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.2.0",
-        "pretty-format": "30.2.0"
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-      "integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.2.0",
+        "@jest/types": "30.4.1",
         "@types/stack-utils": "^2.0.3",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
-        "micromatch": "^4.0.8",
-        "pretty-format": "30.2.0",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
       },
@@ -4376,16 +4361,29 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-message-util/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/jest-mock": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-      "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.2.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-util": "30.2.0"
+        "jest-util": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -4410,9 +4408,9 @@
       }
     },
     "node_modules/jest-regex-util": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4420,18 +4418,18 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.2.0.tgz",
-      "integrity": "sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+      "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.2.0",
+        "jest-haste-map": "30.4.1",
         "jest-pnp-resolver": "^1.2.3",
-        "jest-util": "30.2.0",
-        "jest-validate": "30.2.0",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
         "slash": "^3.0.0",
         "unrs-resolver": "^1.7.11"
       },
@@ -4440,46 +4438,46 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.2.0.tgz",
-      "integrity": "sha512-xTOIGug/0RmIe3mmCqCT95yO0vj6JURrn1TKWlNbhiAefJRWINNPgwVkrVgt/YaerPzY3iItufd80v3lOrFJ2w==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jest-regex-util": "30.0.1",
-        "jest-snapshot": "30.2.0"
+        "jest-regex-util": "30.4.0",
+        "jest-snapshot": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.2.0.tgz",
-      "integrity": "sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.2.0",
-        "@jest/environment": "30.2.0",
-        "@jest/test-result": "30.2.0",
-        "@jest/transform": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/console": "30.4.1",
+        "@jest/environment": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
-        "jest-docblock": "30.2.0",
-        "jest-environment-node": "30.2.0",
-        "jest-haste-map": "30.2.0",
-        "jest-leak-detector": "30.2.0",
-        "jest-message-util": "30.2.0",
-        "jest-resolve": "30.2.0",
-        "jest-runtime": "30.2.0",
-        "jest-util": "30.2.0",
-        "jest-watcher": "30.2.0",
-        "jest-worker": "30.2.0",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-haste-map": "30.4.1",
+        "jest-leak-detector": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-resolve": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "jest-worker": "30.4.1",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -4488,32 +4486,32 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.2.0.tgz",
-      "integrity": "sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.2.0",
-        "@jest/fake-timers": "30.2.0",
-        "@jest/globals": "30.2.0",
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/globals": "30.4.1",
         "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.2.0",
-        "@jest/transform": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "cjs-module-lexer": "^2.1.0",
         "collect-v8-coverage": "^1.0.2",
-        "glob": "^10.3.10",
+        "glob": "^10.5.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.2.0",
-        "jest-message-util": "30.2.0",
-        "jest-mock": "30.2.0",
-        "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.2.0",
-        "jest-snapshot": "30.2.0",
-        "jest-util": "30.2.0",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -4522,9 +4520,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.2.0.tgz",
-      "integrity": "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4533,20 +4531,20 @@
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/plugin-syntax-typescript": "^7.27.1",
         "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.2.0",
+        "@jest/expect-utils": "30.4.1",
         "@jest/get-type": "30.1.0",
-        "@jest/snapshot-utils": "30.2.0",
-        "@jest/transform": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/snapshot-utils": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "babel-preset-current-node-syntax": "^1.2.0",
         "chalk": "^4.1.2",
-        "expect": "30.2.0",
+        "expect": "30.4.1",
         "graceful-fs": "^4.2.11",
-        "jest-diff": "30.2.0",
-        "jest-matcher-utils": "30.2.0",
-        "jest-message-util": "30.2.0",
-        "jest-util": "30.2.0",
-        "pretty-format": "30.2.0",
+        "jest-diff": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1",
         "semver": "^7.7.2",
         "synckit": "^0.11.8"
       },
@@ -4555,18 +4553,18 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-      "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.2.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.2"
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -4586,18 +4584,18 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.2.0.tgz",
-      "integrity": "sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+      "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "@jest/types": "30.2.0",
+        "@jest/types": "30.4.1",
         "camelcase": "^6.3.0",
         "chalk": "^4.1.2",
         "leven": "^3.1.0",
-        "pretty-format": "30.2.0"
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -4617,19 +4615,19 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.2.0.tgz",
-      "integrity": "sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+      "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.2.0",
-        "@jest/types": "30.2.0",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
-        "jest-util": "30.2.0",
+        "jest-util": "30.4.1",
         "string-length": "^4.0.2"
       },
       "engines": {
@@ -4637,15 +4635,15 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.2.0.tgz",
-      "integrity": "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.2.0",
+        "jest-util": "30.4.1",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.1.1"
       },
@@ -4676,19 +4674,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/js2xmlparser": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
@@ -4700,9 +4685,9 @@
       }
     },
     "node_modules/jsdoc": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.4.tgz",
-      "integrity": "sha512-zeFezwyXeG4syyYHbvh1A967IAqq/67yXtXvuL5wnqCkFZe8I0vKfm+EO+YEvLguo6w9CDUbrAXVtJSHh2E8rw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
+      "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4757,15 +4742,14 @@
       }
     },
     "node_modules/jsdoc-parse": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.2.4.tgz",
-      "integrity": "sha512-MQA+lCe3ioZd0uGbyB3nDCDZcKgKC7m/Ivt0LgKZdUoOlMJxUWJQ3WI6GeyHp9ouznKaCjlp7CU9sw5k46yZTw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.2.5.tgz",
+      "integrity": "sha512-8JaSNjPLr2IuEY4Das1KM6Z4oLHZYUnjRrr27hKSa78Cj0i5Lur3DzNnCkz+DfrKBDoljGMoWOiBVQbtUZJBPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-back": "^6.2.2",
         "find-replace": "^5.0.1",
-        "lodash.omit": "^4.5.0",
         "sort-array": "^5.0.0"
       },
       "engines": {
@@ -4773,9 +4757,9 @@
       }
     },
     "node_modules/jsdoc-to-markdown": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-9.1.2.tgz",
-      "integrity": "sha512-0rhxIZeolCJzQ1SPIqmdtPd4VsK8Jt22sKUnnjHpFaXPDkhmdEuZhkrUQKuQidXGi+j3otleQyqn2BEYhxOpYA==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-9.1.3.tgz",
+      "integrity": "sha512-i9wi+6WHX0WKziv0ar88T8h7OmxA0LWdQaV23nY6uQyKvdUPzVt0o6YAaOceFuKRF5Rvlju5w/KnZBfdpDAlnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4785,7 +4769,7 @@
         "config-master": "^3.1.0",
         "dmd": "^7.1.1",
         "jsdoc-api": "^9.3.5",
-        "jsdoc-parse": "^6.2.4",
+        "jsdoc-parse": "^6.2.5",
         "walk-back": "^5.1.1"
       },
       "bin": {
@@ -4972,21 +4956,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
-      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead.",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5121,16 +5090,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5147,11 +5116,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -5170,19 +5139,19 @@
       }
     },
     "node_modules/mkver": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/mkver/-/mkver-4.3.0.tgz",
-      "integrity": "sha512-RaUgBLncA+E8JMMRIsmGh1N6ykZIm/SJdIfUesh+yx91l5uVP5IXEzgyyR8M+VsPhPFtbbSKloys3IGpE3WX4g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mkver/-/mkver-5.0.1.tgz",
+      "integrity": "sha512-f6nuAbCTtcTsA7Q6IQQzKkjowClVFO+wp2rspUYyBMfeYAnKbh14cONogjoNfHC9KlDqpcCNF2i+ylG/Nv8DGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "semver": "^7.7.2"
+        "semver": "^7.8.2"
       },
       "bin": {
         "mkver": "dist/mkver.js"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/ms": {
@@ -5193,9 +5162,9 @@
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.3.tgz",
-      "integrity": "sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5230,13 +5199,13 @@
       "license": "ISC"
     },
     "node_modules/nock": {
-      "version": "14.0.10",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.10.tgz",
-      "integrity": "sha512-Q7HjkpyPeLa0ZVZC5qpxBt5EyLczFJ91MEewQiIi9taWuA0KB/MDJlUWtON+7dGouVdADTQsf9RA7TZk6D8VMw==",
+      "version": "14.0.16",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.16.tgz",
+      "integrity": "sha512-8r4KEc6nT1D/fdLD/R1BO1CPaVEL8o40u/guFRJlXabN7vr3RmMqyjsY5Krt0nMwhsOAwXQ/mtN5vy5Jh3aErg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@mswjs/interceptors": "^0.39.5",
+        "@mswjs/interceptors": "^0.41.0",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       },
@@ -5402,19 +5371,6 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -5599,9 +5555,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5615,15 +5571,16 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "30.0.5",
+        "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -5710,10 +5667,19 @@
       ],
       "license": "MIT"
     },
-    "node_modules/react-is": {
+    "node_modules/react-is-18": {
+      "name": "react-is",
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "dev": true,
       "license": "MIT"
     },
@@ -5750,7 +5716,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-cwd/node_modules/resolve-from": {
+    "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
@@ -5758,16 +5724,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/reusify": {
@@ -5806,9 +5762,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5842,11 +5798,17 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -6040,13 +6002,13 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -6126,13 +6088,13 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.9"
+        "@pkgr/core": "^0.3.6"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -6216,6 +6178,54 @@
         "node": "*"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -6237,9 +6247,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6250,19 +6260,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.4.tgz",
-      "integrity": "sha512-ccVcRABct5ZELCT5U0+DZwkXMCcOCLi2doHRrKy1nK/s7J7bch6TzJMsrY09WxgUUIP/ITfmcDS8D2yl63rnXw==",
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.2",
+        "semver": "^7.8.0",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -6279,7 +6289,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -6377,9 +6387,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6429,45 +6439,48 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "napi-postinstall": "^0.3.0"
+        "napi-postinstall": "^0.3.4"
       },
       "funding": {
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-        "@unrs/resolver-binding-android-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-x64": "1.11.1",
-        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -6754,23 +6767,10 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/write-file-atomic/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -6824,9 +6824,9 @@
       "license": "ISC"
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tibber-api",
-  "version": "5.5.2",
+  "version": "5.6.0",
   "description": "Node.js module for connecting to Tibber API and extract data from your connected homes, including realtime data from Tibber Pulse.",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
@@ -26,24 +26,24 @@
     "url": "git+https://github.com/bisand/tibber-api.git"
   },
   "dependencies": {
-    "ws": "^8.18.3"
+    "ws": "^8.21.0"
   },
   "devDependencies": {
-    "@jest/test-sequencer": "^30.2.0",
+    "@jest/test-sequencer": "^30.4.1",
     "@types/jest": "^30.0.0",
-    "@types/node": "^22.15.1",
+    "@types/node": "^26.1.0",
     "@types/ws": "^8.18.1",
-    "@typescript-eslint/eslint-plugin": "^8.45.0",
-    "@typescript-eslint/parser": "^8.45.0",
-    "eslint": "^9.36.0",
-    "jest": "^30.2.0",
-    "jsdoc": "^4.0.4",
-    "jsdoc-to-markdown": "^9.1.2",
-    "mkver": "^4.3.0",
-    "nock": "^14.0.10",
-    "prettier": "^3.6.2",
-    "ts-jest": "^29.4.4",
-    "typescript": "^5.9.3",
+    "@typescript-eslint/eslint-plugin": "^8.62.1",
+    "@typescript-eslint/parser": "^8.62.1",
+    "eslint": "^10.6.0",
+    "jest": "^30.4.2",
+    "jsdoc": "^4.0.5",
+    "jsdoc-to-markdown": "^9.1.3",
+    "mkver": "^5.0.1",
+    "nock": "^14.0.16",
+    "prettier": "^3.9.4",
+    "ts-jest": "^29.4.11",
+    "typescript": "^6.0.3",
     "websocket": "^1.0.35"
   },
   "directories": {
@@ -60,6 +60,9 @@
   ],
   "author": "André Biseth",
   "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "bugs": {
     "url": "https://github.com/bisand/tibber-api/issues"
   },

--- a/src/gql/energy.gql.ts
+++ b/src/gql/energy.gql.ts
@@ -1,5 +1,5 @@
 export const gqlCurrentEnergyPrices = `
-query getCurrentEnergyPrice {
+query getCurrentEnergyPrices($resolution:PriceInfoResolution = HOURLY) {
   viewer {
     homes {
       id
@@ -8,14 +8,14 @@ query getCurrentEnergyPrice {
         validFrom
         validTo
         status
-        priceInfo{
+        priceInfo(resolution:$resolution) {
           current{
             total
             energy
             tax
             startsAt
             currency
-            level            
+            level
           }
         }
       }
@@ -25,7 +25,7 @@ query getCurrentEnergyPrice {
 `;
 
 export const gqlCurrentEnergyPrice = `
-query getCurrentEnergyPrice($homeId:ID!) {
+query getCurrentEnergyPrice($homeId:ID!, $resolution:PriceInfoResolution = HOURLY) {
   viewer {
     home(id:$homeId) {
       id
@@ -34,14 +34,14 @@ query getCurrentEnergyPrice($homeId:ID!) {
         validFrom
         validTo
         status
-        priceInfo{
+        priceInfo(resolution:$resolution) {
           current{
             total
             energy
             tax
             startsAt
             currency
-            level            
+            level
           }
         }
       }

--- a/src/gql/updateHome.gql.ts
+++ b/src/gql/updateHome.gql.ts
@@ -1,0 +1,16 @@
+export const gqlUpdateHome = `
+mutation updateHome($input: UpdateHomeInput!) {
+  updateHome(input: $input) {
+    id
+    timeZone
+    appNickname
+    appAvatar
+    size
+    type
+    numberOfResidents
+    primaryHeatingSource
+    hasVentilationSystem
+    mainFuseSize
+  }
+}
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,6 @@ import { TibberQuery } from './nodes/TibberQuery';
 import { TibberQueryBase } from './nodes/TibberQueryBase';
 import { UrlTools } from './nodes/models/tools';
 import { IConfig } from './models/IConfig';
+import { IUpdateHomeInput } from './models/IUpdateHomeInput';
 
-export { TibberFeed, TibberQuery, TibberQueryBase, UrlTools, IConfig as IConfig };
+export { TibberFeed, TibberQuery, TibberQueryBase, UrlTools, IConfig as IConfig, IUpdateHomeInput };

--- a/src/models/IUpdateHomeInput.ts
+++ b/src/models/IUpdateHomeInput.ts
@@ -1,0 +1,15 @@
+import { HeatingSource } from './enums/HeatingSource';
+import { HomeAvatar } from './enums/HomeAvatar';
+import { HomeType } from './enums/HomeType';
+
+export interface IUpdateHomeInput {
+    homeId: string;
+    appNickname?: string;
+    appAvatar?: HomeAvatar;
+    size?: number;
+    type?: HomeType;
+    numberOfResidents?: number;
+    primaryHeatingSource?: HeatingSource;
+    hasVentilationSystem?: boolean;
+    mainFuseSize?: number;
+}

--- a/src/nodes/TibberQuery.ts
+++ b/src/nodes/TibberQuery.ts
@@ -9,7 +9,9 @@ import { gqlHomes, gqlHomesComplete } from '../gql/homes.gql';
 import { gqlHome, gqlHomeComplete } from '../gql/home.gql';
 import { gqlCurrentEnergyPrice, gqlTodaysEnergyPrices, gqlTomorrowsEnergyPrices, gqlCurrentEnergyPrices } from '../gql/energy.gql';
 import { gqlSendPushNotification } from '../gql/sendPushNotification.gql';
+import { gqlUpdateHome } from '../gql/updateHome.gql';
 import { ISendPushNotification } from '../models/ISendPushNotification';
+import { IUpdateHomeInput } from '../models/IUpdateHomeInput';
 import { AppScreen } from '../models/enums/AppScreen';
 import { TibberQueryBase } from './TibberQueryBase';
 
@@ -80,10 +82,11 @@ export class TibberQuery extends TibberQueryBase {
     /**
      * Get current energy price for selected home.
      * @param homeId Tibber home ID
+     * @param resolution Either HOURLY or QUARTER_HOURLY
      * @return IPrice object
      */
-    public async getCurrentEnergyPrice(homeId: string): Promise<IPrice> {
-        const variables = { homeId };
+    public async getCurrentEnergyPrice(homeId: string, resolution: string = PriceResolution.HOURLY): Promise<IPrice> {
+        const variables = { homeId, resolution };
         const result = await this.query(gqlCurrentEnergyPrice, variables);
         if (result && result.viewer && result.viewer.home) {
             const home: IHome = result.viewer.home;
@@ -97,10 +100,12 @@ export class TibberQuery extends TibberQueryBase {
 
     /**
      * Get current energy prices from all homes registered to current user
+     * @param resolution Either HOURLY or QUARTER_HOURLY
      * @return Array of IPrice
      */
-    public async getCurrentEnergyPrices(): Promise<IPrice[]> {
-        const result = await this.query(gqlCurrentEnergyPrices);
+    public async getCurrentEnergyPrices(resolution: string = PriceResolution.HOURLY): Promise<IPrice[]> {
+        const variables = { resolution };
+        const result = await this.query(gqlCurrentEnergyPrices, variables);
         if (result && result.viewer && Array.isArray(result.viewer.homes)) {
             const homes: IHome[] = result.viewer.homes;
             const prices = homes.map((item: IHome) => {
@@ -204,5 +209,19 @@ export class TibberQuery extends TibberQueryBase {
         if (result.sendPushNotification || result.errors) {
             return Object.assign({} as ISendPushNotification, result);
         } else return Object.assign({}, { errors: [{ message: 'Undefined error' }] } as ISendPushNotification);
+    }
+
+    /**
+     * Update home information.
+     * @param input IUpdateHomeInput object. homeId is required, all other properties are optional.
+     * @return IHome object with the updated home.
+     */
+    public async updateHome(input: IUpdateHomeInput): Promise<IHome> {
+        const variables = { input };
+        const result = await this.query(gqlUpdateHome, variables);
+        if (result && result.updateHome) {
+            return Object.assign({} as IHome, result.updateHome);
+        }
+        return result && (result.error || result.errors) ? result : {};
     }
 }

--- a/tests/test1-integration-tibber-query.ts
+++ b/tests/test1-integration-tibber-query.ts
@@ -104,6 +104,22 @@ test('TibberQuery - Should be created', () => {
 //     });
 // }, 30000);
 
+test('TibberQuery.getCurrentEnergyPrice() should be valid', async () => {
+    const price = await tibberQuery.getCurrentEnergyPrice('96a14971-525a-4420-aae9-e5aedaa129ff');
+    expect(price).toBeDefined();
+    expect(price.total).toBeGreaterThan(0);
+    expect(price.startsAt).toBeDefined();
+    expect(new Date(String(price.startsAt)).getMinutes()).toBe(0);
+}, 30000);
+
+test('TibberQuery.getCurrentEnergyPrice() should be valid for 15 min intervals', async () => {
+    const price = await tibberQuery.getCurrentEnergyPrice('96a14971-525a-4420-aae9-e5aedaa129ff', PriceResolution.QUARTER_HOURLY);
+    expect(price).toBeDefined();
+    expect(price.total).toBeGreaterThan(0);
+    expect(price.startsAt).toBeDefined();
+    expect(new Date(String(price.startsAt)).getMinutes() % 15).toBe(0);
+}, 30000);
+
 test('TibberQuery.getTodaysEnergyPrices() should be valid', async () => {
     const prices = await tibberQuery.getTodaysEnergyPrices('96a14971-525a-4420-aae9-e5aedaa129ff');
     expect(prices).toBeDefined();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     /* Basic Options */
     "incremental": true,                   /* Enable incremental compilation */
-    "target": "ES2017",                    /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "commonjs",                  /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "target": "ES2022",                    /* Specify ECMAScript target version. ES2022 is fully supported by Node.js 18+. */
+    "module": "node16",                    /* Specify module code generation. 'node16' emits CommonJS for .ts files in a package without "type": "module". */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
@@ -36,7 +36,7 @@
     // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
     /* Module Resolution Options */
-    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node16",          /* Specify module resolution strategy. 'node16' matches Node.js CJS/ESM resolution rules. */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
## Summary

- **Fixes #189**: `getCurrentEnergyPrice()` and `getCurrentEnergyPrices()` now accept an optional resolution parameter (`HOURLY` | `QUARTER_HOURLY`, default `HOURLY`), completing what #188 started for today's/tomorrow's prices. Verified live against the demo API: `QUARTER_HOURLY` returns the current 15-minute price slot.
- **New `updateHome()` mutation** with `IUpdateHomeInput` model (needed for bisand/node-red-contrib-tibber-api#68). Note: `sendMeterReading` from that issue is **not** implemented because Tibber has removed it from their schema (introspection confirms it is no longer in `RootMutation`, and the changelog marks it as a deprecated no-op).
- **Dependency refresh** ahead of the npm release for Node-RED usage: all deps to latest (TypeScript 6, eslint 10, jest 30.4, ws 8.21), tsconfig modernized to `module: node16` / `target: ES2022` (TS6 deprecates `moduleResolution: node10`), and `engines.node >= 18` declared to match Node-RED 4.x requirements.
- Adds a Claude Code skill (`.claude/skills/tibber-graphql-api/`) summarizing the Tibber GraphQL API docs.

Supersedes the dependency bumps in #191.

## Test plan

- `npm test`: 11 suites / 37 tests pass, including two new live integration tests for current price at hourly and quarter-hourly resolution.
- After merge: create release `v5.6.0` to publish to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)