### PR TITLE
Switch npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,5 +1,7 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+# This workflow will run tests using node and then publish the package to npm when a release is created.
+# Publishing uses npm trusted publishing (OIDC) — no npm token secret is needed.
+# The trusted publisher must be configured on npmjs.com for this repository and workflow file.
+# For more information see: https://docs.npmjs.com/trusted-publishers
 
 name: Node.js Package
 
@@ -22,19 +24,20 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
           registry-url: https://registry.npmjs.org/
+      # Trusted publishing requires npm >= 11.5.1
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build
       - if: ${{ github.event.release.prerelease }}
         run: npm publish . --tag beta
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
       - if: ${{ !github.event.release.prerelease }}
         run: npm publish .
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
The v5.6.0 publish failed with E404 on PUT — the npm_token secret is expired/revoked (npm killed long-lived classic tokens in late 2025). This switches the publish job to npm trusted publishing (OIDC): `id-token: write` permission, npm >= 11.5.1, no token secret.

Requires the trusted publisher to be configured on npmjs.com for `tibber-api` (repo bisand/tibber-api, workflow `npm-publish.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)